### PR TITLE
[Satisforestry] Power Hub fix

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -39,6 +39,7 @@ dependencies {
     devOnlyNonPublishable(rfg.deobf("curse.maven:dragonapi-235591:4722480"))
     devOnlyNonPublishable(rfg.deobf"curse.maven:cavecontrol-235605:4721202")
     devOnlyNonPublishable(rfg.deobf("curse.maven:chromaticraft-235590:4721192"))
+    devOnlyNonPublishable(rfg.deobf("curse.maven:satisforestry-430986:4721194"))
 
     devOnlyNonPublishable(rfg.deobf(project.files("libs/DragonRealmCore 1.7.10 V33a.jar")))
 }

--- a/src/main/java/cc/unilock/chromatifixes/LateMixinLoader.java
+++ b/src/main/java/cc/unilock/chromatifixes/LateMixinLoader.java
@@ -19,6 +19,7 @@ public class LateMixinLoader implements ILateMixinLoader {
     public List<String> getMixins(Set<String> loadedMods) {
         final boolean cavecontrol = loadedMods.contains("CaveControl");
         final boolean chromaticraft = loadedMods.contains("ChromatiCraft");
+        final boolean satisforestry = loadedMods.contains("Satisforestry");
         final boolean dragonrealmcore = loadedMods.contains("DragonRealmCore");
 
         List<String> mixins = new ArrayList<>();
@@ -44,6 +45,10 @@ public class LateMixinLoader implements ILateMixinLoader {
             mixins.add("chromaticraft.TileEntityCrystalBroadcasterMixin");
             mixins.add("chromaticraft.TileEntityLumenAlvearyEffectMixins");
             mixins.add("chromaticraft.TileEntityWirelessPoweredMixin");
+        }
+        if (satisforestry) {
+            mixins.add("satisforestry.invokers.TileMinerConnectionInvoker");
+            mixins.add("satisforestry.TileShaftConnectionMixin");
         }
         if (dragonrealmcore) {
             mixins.add("dragonrealmcore.BlockT2HexGeneratorMixin");

--- a/src/main/java/cc/unilock/chromatifixes/mixin/late/satisforestry/TileShaftConnectionMixin.java
+++ b/src/main/java/cc/unilock/chromatifixes/mixin/late/satisforestry/TileShaftConnectionMixin.java
@@ -1,0 +1,44 @@
+package cc.unilock.chromatifixes.mixin.late.satisforestry;
+
+import Reika.RotaryCraft.API.Power.ShaftPowerReceiver;
+import Reika.Satisforestry.Blocks.BlockSFMultiBase.TileShaftConnection;
+import cc.unilock.chromatifixes.mixin.late.satisforestry.invokers.TileMinerConnectionInvoker;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+@Mixin(value = TileShaftConnection.class, remap = false)
+abstract class TileShaftConnectionMixin {
+
+    /**
+     * @author thegamemaster1234
+     * @reason fix instanceof checks to allow power hub to work on pressurizer
+     */
+    @Overwrite
+    public void setOmega(int omega) {
+        Object root = ((TileMinerConnectionInvoker)this)._getRoot();
+        if (((TileShaftConnection)(Object)this).isReceiving() && root != null)
+            ((ShaftPowerReceiver)root).setOmega(omega);
+    }
+
+    /**
+     * @author thegamemaster1234
+     * @reason fix instanceof checks to allow power hub to work on pressurizer
+     */
+    @Overwrite
+    public void setTorque(int torque) {
+        Object root = ((TileMinerConnectionInvoker)this)._getRoot();
+        if (((TileShaftConnection)(Object)this).isReceiving() && root != null)
+            ((ShaftPowerReceiver)root).setTorque(torque);
+    }
+
+    /**
+     * @author thegamemaster1234
+     * @reason fix instanceof checks to allow power hub to work on pressurizer
+     */
+    @Overwrite
+    public void setPower(long power) {
+        Object root = ((TileMinerConnectionInvoker)this)._getRoot();
+        if (((TileShaftConnection)(Object)this).isReceiving() && root != null)
+            ((ShaftPowerReceiver)root).setPower(power);
+    }
+}

--- a/src/main/java/cc/unilock/chromatifixes/mixin/late/satisforestry/invokers/TileMinerConnectionInvoker.java
+++ b/src/main/java/cc/unilock/chromatifixes/mixin/late/satisforestry/invokers/TileMinerConnectionInvoker.java
@@ -1,0 +1,12 @@
+package cc.unilock.chromatifixes.mixin.late.satisforestry.invokers;
+
+import Reika.Satisforestry.Blocks.BlockSFMultiBase;
+import Reika.Satisforestry.Miner.TileResourceHarvesterBase;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(value = BlockSFMultiBase.TileMinerConnection.class, remap = false)
+public interface TileMinerConnectionInvoker<T extends TileResourceHarvesterBase> {
+    @Invoker("getRoot")
+    T _getRoot();
+}


### PR DESCRIPTION
Adds a patch for Satisforestry:

The Power Hub, responsible for transmitting RotaryCraft rotational power to the controller block, was incorrectly programmed to only allow itself to function when the controller was an instance of the miner multiblock controller. This caused the pressurizer multiblock to be unable to receive RotaryCraft power.

Responsible code:
https://github.com/ReikaKalseki/Satisforestry/blob/caeb3eece31286b953b14dbfe2a8570196376835/Blocks/BlockSFMultiBase.java#L359

This patch replaces the functions responsible with ones that instead check for if the controller is valid, the structure is complete, and the controller is capable of receiving shaft power.