### PR TITLE
[ReactorCraft] Heat Pipe, Coolant Cell, Centrifuge patches

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -39,6 +39,8 @@ dependencies {
     devOnlyNonPublishable(rfg.deobf("curse.maven:dragonapi-235591:4722480"))
     devOnlyNonPublishable(rfg.deobf"curse.maven:cavecontrol-235605:4721202")
     devOnlyNonPublishable(rfg.deobf("curse.maven:chromaticraft-235590:4721192"))
+    devOnlyNonPublishable(rfg.deobf("curse.maven:reactorcraft-235593:4721203"))
+    devOnlyNonPublishable(rfg.deobf("curse.maven:rotarycraft-235596:4721191"))
     devOnlyNonPublishable(rfg.deobf("curse.maven:satisforestry-430986:4721194"))
 
     devOnlyNonPublishable(rfg.deobf(project.files("libs/DragonRealmCore 1.7.10 V33a.jar")))

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -43,5 +43,6 @@ dependencies {
     devOnlyNonPublishable(rfg.deobf("curse.maven:rotarycraft-235596:4721191"))
     devOnlyNonPublishable(rfg.deobf("curse.maven:satisforestry-430986:4721194"))
 
+    devOnlyNonPublishable(rfg.deobf(project.files("libs/Waila-1.5.10_1.7.10.jar")))
     devOnlyNonPublishable(rfg.deobf(project.files("libs/DragonRealmCore 1.7.10 V33a.jar")))
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -39,6 +39,8 @@ dependencies {
     devOnlyNonPublishable(rfg.deobf("curse.maven:dragonapi-235591:4722480"))
     devOnlyNonPublishable(rfg.deobf"curse.maven:cavecontrol-235605:4721202")
     devOnlyNonPublishable(rfg.deobf("curse.maven:chromaticraft-235590:4721192"))
+    devOnlyNonPublishable(rfg.deobf("curse.maven:reactorcraft-235593:4721203"))
+    devOnlyNonPublishable(rfg.deobf("curse.maven:rotarycraft-235596:4721191"))
 
     devOnlyNonPublishable(rfg.deobf(project.files("libs/DragonRealmCore 1.7.10 V33a.jar")))
 }

--- a/src/main/java/cc/unilock/chromatifixes/LateMixinLoader.java
+++ b/src/main/java/cc/unilock/chromatifixes/LateMixinLoader.java
@@ -21,6 +21,7 @@ public class LateMixinLoader implements ILateMixinLoader {
         final boolean chromaticraft = loadedMods.contains("ChromatiCraft");
         final boolean satisforestry = loadedMods.contains("Satisforestry");
         final boolean dragonrealmcore = loadedMods.contains("DragonRealmCore");
+        final boolean reactorcraft = loadedMods.contains("ReactorCraft");
 
         List<String> mixins = new ArrayList<>();
 
@@ -55,6 +56,15 @@ public class LateMixinLoader implements ILateMixinLoader {
             if (ChromatiFixesConfig.energizationManagerFix) {
                 mixins.add("dragonrealmcore.EnergizationManagerMixin");
             }
+        }
+        if (reactorcraft) {
+            mixins.add("reactorcraft.accessor.TileEntityHeatPipeAccessor");
+            mixins.add("reactorcraft.accessor.TileEntityNuclearBoilerAccessor");
+            mixins.add("reactorcraft.accessor.TileEntityReactorBaseAccessor");
+            mixins.add("reactorcraft.accessor.TileEntityWaterCellAccessor");
+            mixins.add("reactorcraft.TileEntityHeatPipeMixin");
+            mixins.add("reactorcraft.TileEntityReactorBaseMixin");
+            mixins.add("reactorcraft.TileEntityWaterCellMixin");
         }
 
         return mixins;

--- a/src/main/java/cc/unilock/chromatifixes/LateMixinLoader.java
+++ b/src/main/java/cc/unilock/chromatifixes/LateMixinLoader.java
@@ -65,6 +65,7 @@ public class LateMixinLoader implements ILateMixinLoader {
             mixins.add("reactorcraft.TileEntityHeatPipeMixin");
             mixins.add("reactorcraft.TileEntityReactorBaseMixin");
             mixins.add("reactorcraft.TileEntityWaterCellMixin");
+            mixins.add("reactorcraft.TileEntityCentrifugeMixin");
         }
 
         return mixins;

--- a/src/main/java/cc/unilock/chromatifixes/LateMixinLoader.java
+++ b/src/main/java/cc/unilock/chromatifixes/LateMixinLoader.java
@@ -20,6 +20,7 @@ public class LateMixinLoader implements ILateMixinLoader {
         final boolean cavecontrol = loadedMods.contains("CaveControl");
         final boolean chromaticraft = loadedMods.contains("ChromatiCraft");
         final boolean dragonrealmcore = loadedMods.contains("DragonRealmCore");
+        final boolean reactorcraft = loadedMods.contains("ReactorCraft");
 
         List<String> mixins = new ArrayList<>();
 
@@ -49,6 +50,15 @@ public class LateMixinLoader implements ILateMixinLoader {
             mixins.add("dragonrealmcore.BlockT2HexGeneratorMixin");
             mixins.add("dragonrealmcore.BlockT3HexGeneratorMixin");
             mixins.add("dragonrealmcore.EnergizationManagerMixin");
+        }
+        if (reactorcraft) {
+            mixins.add("reactorcraft.accessor.TileEntityHeatPipeAccessor");
+            mixins.add("reactorcraft.accessor.TileEntityNuclearBoilerAccessor");
+            mixins.add("reactorcraft.accessor.TileEntityReactorBaseAccessor");
+            mixins.add("reactorcraft.accessor.TileEntityWaterCellAccessor");
+            mixins.add("reactorcraft.TileEntityHeatPipeMixin");
+            mixins.add("reactorcraft.TileEntityReactorBaseMixin");
+            mixins.add("reactorcraft.TileEntityWaterCellMixin");
         }
 
         return mixins;

--- a/src/main/java/cc/unilock/chromatifixes/mixin/late/reactorcraft/TileEntityCentrifugeMixin.java
+++ b/src/main/java/cc/unilock/chromatifixes/mixin/late/reactorcraft/TileEntityCentrifugeMixin.java
@@ -1,0 +1,19 @@
+package cc.unilock.chromatifixes.mixin.late.reactorcraft;
+
+import Reika.ReactorCraft.TileEntities.Processing.TileEntityCentrifuge;
+import net.minecraftforge.common.util.ForgeDirection;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+@Mixin(value = TileEntityCentrifuge.class, remap = false)
+public class TileEntityCentrifugeMixin {
+
+    /**
+     * @author thegamemaster1234
+     * @reason fix isotope centrifuge allowing items to exit from the top/bottom instead of the sides
+     */
+    @Overwrite
+    public boolean canItemExitToSide(ForgeDirection dir) {
+        return (dir.offsetY == 0);
+    }
+}

--- a/src/main/java/cc/unilock/chromatifixes/mixin/late/reactorcraft/TileEntityHeatPipeMixin.java
+++ b/src/main/java/cc/unilock/chromatifixes/mixin/late/reactorcraft/TileEntityHeatPipeMixin.java
@@ -1,0 +1,141 @@
+package cc.unilock.chromatifixes.mixin.late.reactorcraft;
+
+import Reika.ChromatiCraft.API.Interfaces.WorldRift;
+import Reika.DragonAPI.Libraries.World.ReikaWorldHelper;
+import Reika.ReactorCraft.Auxiliary.ReactorTyped;
+import Reika.ReactorCraft.Base.TileEntityNuclearBoiler;
+import Reika.ReactorCraft.Registry.ReactorType;
+import Reika.ReactorCraft.TileEntities.TileEntityHeatPipe;
+import Reika.RotaryCraft.Auxiliary.Interfaces.HeatConduction;
+import cc.unilock.chromatifixes.mixin.late.reactorcraft.accessor.TileEntityHeatPipeAccessor;
+import cc.unilock.chromatifixes.mixin.late.reactorcraft.accessor.TileEntityNuclearBoilerAccessor;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = TileEntityHeatPipe.class, remap = false)
+public class TileEntityHeatPipeMixin {
+
+    /**
+     * @author thegamemaster1234
+     * @reason enable heat pipe passive heat loss and temperature visuals
+     */
+    @Inject(method="updateEntity", at=@At("TAIL"))
+    public void updateEntity(World world, int x, int y, int z, int meta, CallbackInfo ci) {
+        TileEntityHeatPipe thisTE = (TileEntityHeatPipe)(Object)this;
+        TileEntityHeatPipeAccessor thisTEAcc = (TileEntityHeatPipeAccessor)this;
+
+        if(!world.isRemote && thisTE.getTicksExisted() % 32 == 0) {
+            thisTEAcc.ventHeatAcc(world, x, y, z);
+        }
+    }
+
+    /**
+     * @author thegamemaster1234
+     * @reason stop heat pipes from losing all energy on world load
+     * <br> only set heat pipes to ambient on first tick if energy value is 0
+     */
+    @Overwrite
+    protected void onFirstTick(World world, int x, int y, int z) {
+        TileEntityHeatPipeAccessor thisTEAcc = (TileEntityHeatPipeAccessor)this;
+        if (thisTEAcc.getHeatEnergy() == 0) {
+            thisTEAcc.setHeatEnergy(ReikaWorldHelper.getAmbientTemperatureAt(world, x, y, z) * 3010.8D);
+        }
+    }
+
+    /**
+     * @author thegamemaster1234
+     * @reason stop heat pipes from setting negative reactor typing or deleting heat for no reason
+     * <br> replacement code based on <a href="https://github.com/ReikaKalseki/ReactorCraft/blob/d788f1bcd33c66758d687faaf692c2668595021b/TileEntities/TileEntityHeatPipe.java#L107">original function by Reika</a>
+     */
+    @Overwrite
+    private void balanceHeat(World world, int x, int y, int z) {
+        TileEntityHeatPipe thisTE = (TileEntityHeatPipe)(Object)this;
+        TileEntityHeatPipeAccessor thisTEAcc = (TileEntityHeatPipeAccessor)this;
+
+        // Check all sides of the block
+        for(ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
+            TileEntity otherTE = thisTE.getAdjacentTileEntity(dir);
+            TileEntityHeatPipe pipe = null;
+
+            // Do nothing if no TE found
+            if (otherTE == null) continue;
+
+            // Check for other heat pipes, with World Rift support
+            if (otherTE instanceof TileEntityHeatPipe tePipe) {
+                pipe = tePipe;
+            } else if (otherTE instanceof WorldRift rift
+                && rift.getTileEntityFrom(dir) instanceof TileEntityHeatPipe tePipe) {
+                pipe = tePipe;
+            }
+
+            if (pipe != null) {
+                thisTEAcc.balanceWithAcc(pipe);
+            } else if (thisTEAcc.canConnectToMachineAcc(otherTE.getBlockType(), otherTE.getBlockMetadata(), dir, otherTE)) {
+                HeatConduction conductor = (HeatConduction)otherTE;
+                double otherHeatEnergy = TileEntityHeatPipe.getNetHeat(conductor);
+                double myHeatEnergy = thisTE.getNetHeatEnergy();
+                double otherTemp = TileEntityHeatPipe.getNetTemperature(conductor);
+                double myTemp = TileEntityHeatPipe.getTemperatureForPipe(thisTE, true);
+
+                // Allow heat intake if the other TE has both more energy and more temperature
+                boolean intake = otherHeatEnergy > myHeatEnergy && otherTemp > myTemp && conductor.allowHeatExtraction();
+                // Allow heat export if the other TE has less temperature
+                boolean outtake = myTemp > otherTemp && conductor.allowExternalHeating();
+                // Heat will not move if the other TE has more temperature but less energy
+
+                if (intake || outtake) {
+                    // Energy difference between sources
+                    // Will be >0 if sending heat, <0 if receiving heat
+                    double transferRate = 0.25;
+                    double energyDiff = (myHeatEnergy - otherHeatEnergy) * transferRate;
+
+                    // MODIFIED: Amount of temperature units to put back in the conductor
+                    int put = TileEntityHeatPipe.getTemperatureForHeat(otherHeatEnergy + energyDiff, conductor);
+
+                    // NEW: Energy lost when modifying heat due to integer truncation
+                    // If difference >0, this represents the amount of energy unable to be sent
+                    // If difference <0, this represents the extra energy taken while balancing
+                    // It might sound like the math needs to be different for each case, but it doesn't!
+                    double remainder = ((otherHeatEnergy + energyDiff) / conductor.heatEnergyPerDegree()) % 1.0D;
+                    remainder *= conductor.heatEnergyPerDegree();
+
+                    // Set the conductor's heat level to recombined total
+                    conductor.setTemperature(put + conductor.getAmbientTemperature());
+
+                    // Adjust heat energy according to the amount given or received
+                    // NEW: Recycle temperature units lost to integer truncation
+                    thisTEAcc.setHeatEnergy(thisTEAcc.getHeatEnergy() - energyDiff + remainder);
+
+                    // Reactor energy typing handling
+                    if (intake) {
+                        ReactorType type = null;
+                        if (otherTE instanceof ReactorTyped typed) {
+                            type = typed.getReactorType();
+                        }
+                        // If conductor has reactor types, gain an amount of those types based on energy received
+                        // MODIFIED: Use heat units instead of energy to prevent uncharacteristically large values
+                        if (type != null) {
+                            thisTEAcc.getReactorTypes().addValue(
+                                type,
+                                TileEntityHeatPipe.getTemperatureForHeat(energyDiff, conductor)
+                            );
+                        }
+                    } else {
+                        // NOTE: This code can now run if energyDiff==0. Unknown if that could do anything weird
+                        // If sending to a boiler, apply the heat types gained
+                        if (otherTE instanceof TileEntityNuclearBoiler) {
+                            // This accessor exists to avoid having to build with Buildcraft :aaaaaa:
+                            ((TileEntityNuclearBoilerAccessor)otherTE).setReactorTypesAcc(thisTEAcc.getReactorTypes());
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/cc/unilock/chromatifixes/mixin/late/reactorcraft/TileEntityReactorBaseMixin.java
+++ b/src/main/java/cc/unilock/chromatifixes/mixin/late/reactorcraft/TileEntityReactorBaseMixin.java
@@ -1,0 +1,24 @@
+package cc.unilock.chromatifixes.mixin.late.reactorcraft;
+
+import Reika.ReactorCraft.Base.TileEntityReactorBase;
+import Reika.ReactorCraft.TileEntities.Fission.TileEntityWaterCell;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = TileEntityReactorBase.class, remap = false)
+public class TileEntityReactorBaseMixin {
+    /**
+     * @author thegamemaster1234
+     * @reason fix coolant cells always being treated as heat conductance 0
+     * <br> NOTE: this enables using coolant cells as type-agnostic conductors i.e. "exploits" (kinda like control rods))
+     */
+    @Inject(method="getHeatEfficiency", at=@At("HEAD"), cancellable = true)
+    public void getHeatEfficiency(TileEntityReactorBase other, CallbackInfoReturnable<Float> ci) {
+        if ((Object)this instanceof TileEntityWaterCell
+            || other instanceof TileEntityWaterCell) {
+            ci.setReturnValue(1.0f);
+        }
+    }
+}

--- a/src/main/java/cc/unilock/chromatifixes/mixin/late/reactorcraft/TileEntityWaterCellMixin.java
+++ b/src/main/java/cc/unilock/chromatifixes/mixin/late/reactorcraft/TileEntityWaterCellMixin.java
@@ -1,0 +1,62 @@
+package cc.unilock.chromatifixes.mixin.late.reactorcraft;
+
+import Reika.ReactorCraft.TileEntities.Fission.TileEntityWaterCell;
+import Reika.ReactorCraft.TileEntities.Fission.TileEntityWaterCell.LiquidStates;
+import cc.unilock.chromatifixes.mixin.late.reactorcraft.accessor.TileEntityReactorBaseAccessor;
+import cc.unilock.chromatifixes.mixin.late.reactorcraft.accessor.TileEntityWaterCellAccessor;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.fluids.*;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+@Mixin(value = TileEntityWaterCell.class, remap = false)
+public class TileEntityWaterCellMixin {
+
+    /**
+     * @author thegamemaster1234
+     * @reason fix coolant cells voiding fluids, based on <a href="https://github.com/ReikaKalseki/ReactorCraft/blob/d788f1bcd33c66758d687faaf692c2668595021b/TileEntities/Fission/TileEntityWaterCell.java#L44">original method by Reika</a>
+     */
+    @Overwrite
+    public void updateEntity(World world, int x, int y, int z, int meta) {
+        TileEntityWaterCell thisTE = (TileEntityWaterCell)(Object)this;
+        TileEntityWaterCellAccessor thisTEAcc = (TileEntityWaterCellAccessor)this;
+        TileEntityReactorBaseAccessor thisTEBaseAcc = (TileEntityReactorBaseAccessor)this;
+
+        // Move fluid downwards to other coolant cells if possible
+        TileEntity downTE = thisTE.getAdjacentTileEntity(ForgeDirection.DOWN);
+        if (downTE instanceof TileEntityWaterCell cellTE) {
+            if (cellTE.getLiquidState() == LiquidStates.EMPTY && thisTE.getLiquidState() != LiquidStates.EMPTY) {
+                cellTE.setLiquidState(thisTE.getLiquidState());
+                thisTE.setLiquidState(LiquidStates.EMPTY);
+            }
+        }
+
+        // Take fluid from above Forge fluid handlers if possible
+        // MODIFIED: Removed explicit reservoir compatibility (unnecessary)
+        // MODIFIED: Now properly checks if the fluid is acceptable before draining it
+        if (thisTE.getLiquidState() == LiquidStates.EMPTY) {
+            TileEntity upTE = thisTE.getAdjacentTileEntity(ForgeDirection.UP);
+
+            if (upTE instanceof IFluidHandler handler) {
+                FluidStack liq = handler.drain(ForgeDirection.DOWN, FluidContainerRegistry.BUCKET_VOLUME, false);
+                if (liq != null) {
+                    LiquidStates liqState = LiquidStates.getState(liq.getFluid());
+                    if (liq.amount >= FluidContainerRegistry.BUCKET_VOLUME
+                        && liqState != null
+                        && liqState != LiquidStates.EMPTY) {
+                        handler.drain(ForgeDirection.DOWN, FluidContainerRegistry.BUCKET_VOLUME, true);
+                        thisTE.setLiquidState(liqState);
+                    }
+                }
+            }
+        }
+
+        // Update temperature
+        thisTEBaseAcc.getThermalTicker().update();
+        if (thisTEBaseAcc.getThermalTicker().checkCap() && !world.isRemote) {
+            thisTEAcc.updateTemperatureAcc(world, x, y, z);
+        }
+    }
+}

--- a/src/main/java/cc/unilock/chromatifixes/mixin/late/reactorcraft/accessor/TileEntityHeatPipeAccessor.java
+++ b/src/main/java/cc/unilock/chromatifixes/mixin/late/reactorcraft/accessor/TileEntityHeatPipeAccessor.java
@@ -1,0 +1,33 @@
+package cc.unilock.chromatifixes.mixin.late.reactorcraft.accessor;
+
+import Reika.DragonAPI.Instantiable.Data.Proportionality;
+import Reika.ReactorCraft.Registry.ReactorType;
+import Reika.ReactorCraft.TileEntities.TileEntityHeatPipe;
+import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(value = TileEntityHeatPipe.class, remap = false)
+public interface TileEntityHeatPipeAccessor {
+    @Accessor
+    double getHeatEnergy();
+
+    @Accessor
+    void setHeatEnergy(double value);
+
+    @Accessor
+    Proportionality<ReactorType> getReactorTypes();
+
+    @Invoker("balanceWith")
+    void balanceWithAcc(TileEntityHeatPipe other);
+
+    @Invoker("canConnectToMachine")
+    boolean canConnectToMachineAcc(Block id, int meta, ForgeDirection dir, TileEntity te);
+
+    @Invoker("ventHeat")
+    void ventHeatAcc(World world, int x, int y, int z);
+}

--- a/src/main/java/cc/unilock/chromatifixes/mixin/late/reactorcraft/accessor/TileEntityNuclearBoilerAccessor.java
+++ b/src/main/java/cc/unilock/chromatifixes/mixin/late/reactorcraft/accessor/TileEntityNuclearBoilerAccessor.java
@@ -1,0 +1,13 @@
+package cc.unilock.chromatifixes.mixin.late.reactorcraft.accessor;
+
+import Reika.DragonAPI.Instantiable.Data.Proportionality;
+import Reika.ReactorCraft.Base.TileEntityNuclearBoiler;
+import Reika.ReactorCraft.Registry.ReactorType;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(value = TileEntityNuclearBoiler.class, remap = false)
+public interface TileEntityNuclearBoilerAccessor {
+    @Invoker("setReactorTypes")
+    void setReactorTypesAcc(Proportionality<ReactorType> p);
+}

--- a/src/main/java/cc/unilock/chromatifixes/mixin/late/reactorcraft/accessor/TileEntityReactorBaseAccessor.java
+++ b/src/main/java/cc/unilock/chromatifixes/mixin/late/reactorcraft/accessor/TileEntityReactorBaseAccessor.java
@@ -1,0 +1,12 @@
+package cc.unilock.chromatifixes.mixin.late.reactorcraft.accessor;
+
+import Reika.DragonAPI.Instantiable.StepTimer;
+import Reika.ReactorCraft.Base.TileEntityReactorBase;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(value = TileEntityReactorBase.class, remap = false)
+public interface TileEntityReactorBaseAccessor {
+    @Accessor
+    StepTimer getThermalTicker();
+}

--- a/src/main/java/cc/unilock/chromatifixes/mixin/late/reactorcraft/accessor/TileEntityWaterCellAccessor.java
+++ b/src/main/java/cc/unilock/chromatifixes/mixin/late/reactorcraft/accessor/TileEntityWaterCellAccessor.java
@@ -1,0 +1,12 @@
+package cc.unilock.chromatifixes.mixin.late.reactorcraft.accessor;
+
+import Reika.ReactorCraft.TileEntities.Fission.TileEntityWaterCell;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(value = TileEntityWaterCell.class, remap = false)
+public interface TileEntityWaterCellAccessor {
+    @Invoker("updateTemperature")
+    void updateTemperatureAcc(World world, int x, int y, int z);
+}


### PR DESCRIPTION
Applies the following changes:
- Heat Pipes no longer void neighbor's entire heat level
- Heat Pipes no longer lose heat energy from integer truncation
- Heat Pipes no longer apply unreasonably large quantities of typed heat to boilers
- Heat Pipes are now subject to passive heat loss (4% of the difference from ambient every 32 ticks)
- Heat Pipes now change color according to their current temperature (side-effect of above change)
- Coolant Cells are considered to have a conduction efficiency of 100% instead of 0%, similar to Control Rods
- Isotope Centrifuge allows item extraction on the sides rather than the top/bottom (previously, other mods or manual interaction was required to extract items, as the top face already accepts fluids and the bottom face already accepts power)

Other Notes:
- Added Waila as a `libs/` manual-install dependency. I couldn't figure out if there was a Maven way to do it, and for some reason the project refuses to build without it.