### PR TITLE
add alwaysRememberLexiconPage

### DIFF
--- a/src/main/java/cc/unilock/dragonfixes/DragonFixesConfig.java
+++ b/src/main/java/cc/unilock/dragonfixes/DragonFixesConfig.java
@@ -44,4 +44,9 @@ public class DragonFixesConfig {
     @Config.DefaultBoolean(false)
     @Config.RequiresMcRestart
     public static boolean replaceRubberWithGemLatex;
+
+    @Config.Comment("Makes the Chromatic Lexicon always save your page")
+    @Config.DefaultBoolean(false)
+    @Config.RequiresMcRestart
+    public static boolean alwaysRememberLexiconPage;
 }

--- a/src/main/java/cc/unilock/dragonfixes/LateMixinLoader.java
+++ b/src/main/java/cc/unilock/dragonfixes/LateMixinLoader.java
@@ -67,6 +67,9 @@ public class LateMixinLoader implements ILateMixinLoader {
             mixins.add("chromaticraft.TileEntityLumenAlvearyTemperatureMatchingEffectMixin");
             mixins.add("chromaticraft.TileEntityPlayerDelegateMixin");
             mixins.add("chromaticraft.TileEntityWirelessPoweredMixin");
+            if (DragonFixesConfig.alwaysRememberLexiconPage) {
+                mixins.add("chromaticraft.ChromaBookGuiMixin");
+            }
         }
         if (dragonapi) {
             mixins.add("dragonapi.AbstractSearchFoundPathMixin");

--- a/src/main/java/cc/unilock/dragonfixes/mixin/late/chromaticraft/ChromaBookGuiMixin.java
+++ b/src/main/java/cc/unilock/dragonfixes/mixin/late/chromaticraft/ChromaBookGuiMixin.java
@@ -1,0 +1,17 @@
+package cc.unilock.dragonfixes.mixin.late.chromaticraft;
+
+import Reika.ChromatiCraft.Base.ChromaBookGui;
+import net.minecraft.client.gui.GuiScreen;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(value = ChromaBookGui.class)
+public abstract class ChromaBookGuiMixin extends GuiScreen {
+
+    @Override
+    protected void keyTyped(char typedChar, int keyCode) {
+        super.keyTyped(typedChar,keyCode);
+        if (keyCode == 1) {
+            ChromaBookGui.lastGui = (ChromaBookGui) (Object) this;
+        }
+    }
+}


### PR DESCRIPTION
Feature:
- Changes the default lexicon behaviour to always save when closed using escape. 

Notes:
- May be bugs or side effects. I only tested for a bit in my world.
- Config default is false because it's a gameplay change and largely untested. 
- mainly made for me but PR in case anyone wants to use or improve. 